### PR TITLE
fix responsiveness for mobile

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -7,12 +7,14 @@
   box-sizing: border-box;
 }
 
-body {
+body, html {
   /* font-family: "Montserrat", sans-serif; */
   /* font-family: "Roboto", sans-serif; */
   font-family: "Poppins", sans-serif;
   display: flex;
   flex-direction: column;
+  overflow-x: hidden;
+  width: 100%;
 }
 
 .container {


### PR DESCRIPTION
### ✨ Pull Request Overview  
Fix to remove unwanted white space below the `footer` on mobile devices by adjusting the `body` and `html` styles.

---

### 🛠️ Fixes & Improvements  
1. **Adjusted `body` and `html` styles**  
   - Added `width: 100%;` and wrapped the `body` and `html` styles to ensure they occupy the full width of the viewport and prevent extra space at the bottom of the page.
   - Added `overflow-x: hidden;` to avoid horizontal scrolling.

---

### 📌 Why These Changes?  
- Prevent unwanted white space from appearing below the `footer` on mobile devices.
- Ensure the `body` and `html` elements use the full width and do not cause overflow issues.

---

Feel free to provide any feedback or additional suggestions! 🙌